### PR TITLE
Add architecture and examples overview docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,81 @@
+# DrawZero Architecture Overview
+
+This document summarizes the internal layout of the DrawZero project so that contributors (and code-generation agents) can quickly orient themselves in the codebase.
+
+## Package layout
+
+```
+src/drawzero/
+├── __init__.py          # Re-exported public API
+├── __main__.py          # CLI entry point (copies examples, draws demo frame)
+├── examples/            # Tutorial-style scripts executed by tests
+└── utils/               # Core rendering, math, and convenience helpers
+```
+
+Other notable top-level folders:
+
+* `docs/` – MkDocs documentation shipped on PyPI; suitable place for additional guides.
+* `tests/` – Pytest and unittest suites that import examples, validate converters, gradients, points, and internationalization helpers.
+
+## Public API surface (`src/drawzero/__init__.py`)
+
+The package exposes a “flat” API meant to mimic turtle/pygame zero ergonomics. All drawing helpers are imported from `utils.draw`, while math helpers come from sibling modules:
+
+* Drawing primitives: `line`, `circle`, `rect`, `polygon`, `text`, `image`, etc.
+* Filled variants share the same renderer entry points by passing `line_width=0`.
+* Animation and timing helpers: `tick`, `sleep`, `run`, `fps`, `quit`.
+* Input helpers proxy the renderer’s key/mouse state (`get_keys_pressed`, `keysdown`, `mousebuttonsdown`, ...).
+* Utilities: `Pt` (vector/turtle hybrid), `Gradient`, `copy_examples`, color constants (`C`, `COLORS`, `ALL_COLORS`).
+
+Every user-facing function ultimately routes through the renderer stack described below.
+
+## Rendering pipeline (`utils.draw` → `utils.renderer`)
+
+`utils.draw` performs argument validation and coercion before delegating to the actual drawing backend. Common steps for each primitive:
+
+1. Convert user-supplied data through converter helpers (`utils.converters`). These functions normalize coordinates, radii, rectangles, and colors, while collecting rich error messages via `BadDrawParmsError` and localized strings in `utils.i18n`.
+2. Choose the backend module depending on the `EJUDGE_MODE` environment variable. GUI builds import `utils.renderer` (pygame-based). Text-mode/CI builds fall back to `utils.renderer_ejudge`, which prints commands for automated judges.
+3. After the renderer call, update cached input event lists so that consumers see mouse/key positions in logical (virtual) coordinates.
+
+### `utils.renderer`
+
+The pygame renderer lazily creates a resizable window and keeps an off-screen copy to survive resizes. Important responsibilities:
+
+* Surface management: `_create_surface()` defers window creation until the first drawing call; `_resize()` rescales existing content when SDL emits a resize event.
+* Primitive drawing: each `draw_*` function handles optional alpha blending by drawing into temporary `pygame.Surface` buffers when needed.
+* Event pump: `draw_tick()` advances the clock (30 FPS target), flushes the event queue, and populates global lists (`keysdown`, `mousebuttonsdown`, etc.) consumed by `utils.draw`.
+* Lifecycle hooks: `atexit.register(_draw_go)` keeps the pygame loop alive until the process exits; `_init()` configures DPI-awareness on Windows and centers the window.
+* Coordinate scaling: setter functions from `utils.screen_size` maintain the mapping between “virtual” 1000×1000 coordinates (used by the API) and the actual window size.
+
+### `utils.renderer_ejudge`
+
+A lightweight stub used when `EJUDGE_MODE=true` (e.g., tests running without a GUI). It mirrors the renderer API but simply prints serialized drawing commands. Screen size is fixed to 1000×1000 so coordinate conversion remains consistent.
+
+## Coordinate transforms (`utils.screen_size`)
+
+DrawZero always exposes a 1000×1000 virtual canvas. `set_virtual_size()` can change that logical resolution, and `set_real_size()` is called by the renderer when it knows the real pixel size. The module exposes helpers to convert between coordinate spaces:
+
+* `to_canvas_x` / `to_canvas_y` – convert virtual coordinates to actual pixels.
+* `from_canvas_x` / `from_canvas_y` – convert back to logical coordinates (used when reporting mouse positions).
+
+All converters and event wrappers rely on this module, so adjust it carefully if supporting non-square canvases.
+
+## Math and utility helpers
+
+* `utils.pt.Pt` implements a mutable 2D vector with turtle-style movement, arithmetic operators, and convenience methods (`forward`, `rotate_around`, `distance`, etc.). Examples rely on it for animation logic.
+* `utils.gradient.Gradient` constructs color ramps over a numeric domain (default 0–1). It uses the same converter/error infrastructure to provide consistent validation.
+* `utils.colors` exposes pygame’s color table both as attribute access (`C.red`) and dictionaries (`COLORS`, `ALL_COLORS`).
+* `utils.key_flags` mirrors pygame key constants so code can use `K.<name>` even when pygame is absent (constants are loaded lazily when available).
+* `utils.copy_examples.copy_examples()` copies `src/drawzero/examples` into the current working directory; the CLI entry point calls it to bootstrap learners.
+
+## Examples (`src/drawzero/examples`)
+
+Short, bilingual scripts demonstrate the API: drawing primitives, loops, animations, gradients, images, and simple interactive games. Tests import many of them to ensure they still execute, so keep side effects (e.g., infinite loops) behind guards if you add new ones.
+
+## Tests (`tests/`)
+
+* `test_examples_gui_mode.py` imports each example module to ensure it runs against the real renderer.
+* `test_examples_text_mode.py` sets `EJUDGE_MODE` and asserts the text renderer paths work.
+* The remaining pytest modules cover specific utilities: converter validation, localized error messages, gradient interpolation, the `Pt` vector API, and `copy_examples()` behavior.
+
+Use these tests as references when extending validation logic or adding new primitives.

--- a/docs/examples_overview.md
+++ b/docs/examples_overview.md
@@ -1,0 +1,30 @@
+# Examples Overview
+
+The `src/drawzero/examples` package contains runnable scripts that double as smoke tests and usage demonstrations. The table below highlights the intent of each script so you can pick a relevant starting point when troubleshooting or extending functionality.
+
+| File | Focus | Key ideas |
+| --- | --- | --- |
+| `00_hello_world.py` | First canvas rendering | Draws a bordered canvas, splits text into two languages, and starts the `run()` loop. |
+| `01_grid_and_coordinates.py` | Coordinate system tour | Renders the helper `grid()`, then annotates various primitives at known coordinates. |
+| `02_loops_and_rgb_colors.py` | Loop-driven art | Uses a `for` loop and random RGB tuples to paint vertical bars with varying heights. |
+| `03_simple_objects.py` | Primitive catalog | Demonstrates every drawing primitive (lines, circles, rotated rectangles, polygons, text alignment). |
+| `04_loops_sin_plot.py` | Math plotting | Plots a sine wave by stitching short line segments along the X axis. |
+| `05_points.py` | `Pt` as vector/turtle | Shows how the `Pt` class supports arithmetic, motion, and turtle-style rotation in loops. |
+| `06_turtle_style.py` | Polygon drawing with `Pt` | Rotates a `Pt` instance to build regular polygons for sides 3–10 using turtle operations. |
+| `07_animation_circles.py` | Minimal animation loop | Varies circle position, radius, and color over time while calling `tick()` each frame. |
+| `08_animation_traffic_light.py` | State-based animation | Reuses a helper to draw a traffic light and uses `sleep()` to cycle colors. |
+| `09_animation_rectangles.py` | Complex animation | Combines `Pt` math with rotation/orbit logic, transparency, and conditional effects. |
+| `10_animation_planets.py` | Orbital motion | Calculates circular motion for a planet/moon pair and redraws every frame. |
+| `11_transparency_and_line_width.py` | Alpha blending and stroke widths | Samples different alpha values and line widths across circles, rectangles, polygons, and ellipses. |
+| `12_images.py` | Image rendering | Loads `cat.png` from the examples folder, demonstrates scaling and alpha when blitting images. |
+| `13_gradients.py` | Gradient helper | Builds several `Gradient` scales and visualizes them through stacked rectangles. |
+| `14_animation_close_vertex.py` | Proximity graph animation | Moves random `Pt` nodes with wrap-around motion, draws lines between nearby pairs, and uses FPS overlay. |
+| `15_animation_firework.py` | Particle system | Implements `Particle` and `Firework` classes with physics updates, gradient-based glow, and clean-up logic. |
+| `16_keyboard_and_mouse.py` | Input handling | Reads key state arrays and event queues to move a square, track typed characters, and follow the mouse. |
+| `17_mouse_tube.py` | Mouse trail effect | Captures `mouse_pos()` each frame, grows concentric circles with a gradient as they age. |
+| `18_game_stars.py` | 3D starfield mini-game | Uses dataclasses, random stars, and WASD/QE controls to navigate through a pseudo-3D field. |
+| `19_game_colors.py` | Reaction game | Displays color words versus actual colors, handles mouse button choices with time penalties. |
+| `20_game_racing.py` | Multiplayer mini-game | Assigns distinct key bindings per car, scrolls a precomputed road, and keeps per-player scores. |
+| `99_errors.py` | Error reporting demo | Forces validation errors under `EJUDGE_MODE` to showcase localized diagnostics emitted by converters. |
+
+When adding new examples, keep them import-safe (tests import modules directly) and prefer finite loops or guard infinite loops with a `if __name__ == "__main__"` block.


### PR DESCRIPTION
## Summary
- add an architecture overview for the DrawZero package internals
- document the intent of each tutorial script under src/drawzero/examples

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f7029148488326b0a1b74f3c1e1717