### PR TITLE
Add detailed documentation for image helper and transparency options

### DIFF
--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,151 @@
+# Working with images
+
+This guide shows how to draw pictures on the canvas with the `image()` helper. It uses simple English and many examples so that high school students who are not native English speakers can follow every step.
+
+## Function signature at a glance
+
+```python
+from drawzero import image
+
+image(image, pos, width: int = None, alpha=255)
+```
+
+The four parameters control what file is loaded, where it appears, how wide it becomes, and how transparent it looks.
+
+| Parameter | What it means | Required? | Typical values |
+|-----------|----------------|-----------|----------------|
+| `image`   | Path to the picture file (for example `'cat.png'` or `this_file_dir / 'cat.png'`) | Yes | PNG, JPG, or other formats that `pygame` can open |
+| `pos`     | Top-left corner of where the picture will be drawn on the canvas | Yes | `(x, y)` tuples like `(100, 200)` |
+| `width`   | Desired width on the canvas. Height changes automatically to keep the same shape. | No | Whole numbers such as `200` or `350` |
+| `alpha`   | Transparency. `255` is fully solid, `0` is invisible. | No | Numbers between `0` and `255` |
+
+> ℹ️ If you want a deeper explanation of transparency, read [Transparency (`alpha`) and line thickness (`line_width`)](transparency_and_line_width.md#understanding-alpha).
+
+## Parameter by parameter
+
+### `image`: choose the file to draw
+
+* Accepts strings with file names, absolute paths, or `pathlib.Path` objects.
+* Relative paths are resolved from the Python file that calls `image()`. A safe pattern is:
+  ```python
+  from pathlib import Path
+  this_file_dir = Path(__file__).resolve().parent
+  image(this_file_dir / 'pictures' / 'cat.png', (100, 100))
+  ```
+* PNG images keep their transparent background. JPG files ignore transparent pixels because the format does not store them.
+* Large images are fine, but very big files slow down loading. For games or animations, keep images under 2000×2000 pixels if possible.
+
+**Common mistakes**
+
+* Typing a wrong folder name. Fix it by printing the full path and checking if the file exists.
+* Forgetting the file extension (`.png`, `.jpg`, `.gif`).
+* Using backslashes (`\`) on Windows inside normal strings. Either use raw strings (`r'images\\cat.png'`) or forward slashes (`'images/cat.png'`).
+
+### `pos`: place the image on the canvas
+
+* The canvas uses the same 1000×1000 virtual coordinate system as the shape primitives.
+* `(0, 0)` is the top-left corner. Increasing `x` moves the picture to the right. Increasing `y` moves it down.
+* `pos` can be a tuple, list, or a `Pt` object.
+* The coordinates represent the **top-left corner** of the image. If you want to center the picture, subtract half of its width and height:
+  ```python
+  image('badge.png', (500 - 128, 500 - 128))
+  ```
+* `image()` will round the numbers to the nearest pixel. Decimals are allowed, but they are converted to integers internally.
+
+### `width`: control the size without breaking proportions
+
+* Leave it as `None` to keep the original size of the file.
+* Pass a positive integer to scale the image horizontally. The helper automatically calculates the matching height so the picture does not look stretched.
+* The value is measured in virtual canvas units. With the default 1000×1000 window, `width=200` shows the image 200 pixels wide.
+* Set `width` to the same value for all frames in an animation to avoid flickering.
+* You can compute the width dynamically. For example, to scale by 50%:
+  ```python
+  original_width = 400
+  image('robot.png', (300, 400), width=original_width // 2)
+  ```
+* Passing `0` or a negative value will raise a `BadDrawParmsError`. Always use a positive integer.
+
+### `alpha`: blend images with the background
+
+* Accepts integers from `0` (fully transparent) to `255` (fully opaque).
+* The default value `255` draws the picture with no extra transparency.
+* Use mid-range values (for example `128`) to create soft shadows, glass effects, or hints of motion.
+* The alpha value applies to the entire image. Per-pixel transparency stored in PNG files still works and is multiplied by this value.
+* Read the [full guide on transparency](transparency_and_line_width.md#understanding-alpha) to see layered examples and mixing tips.
+
+## Step-by-step examples
+
+### Example 1 – show a mascot in the corner
+
+```python
+from drawzero import *
+
+fill('white')
+image('mascot.png', (50, 50))
+```
+
+The mascot keeps its original size. The white background makes the colors easy to see.
+
+### Example 2 – center an image and scale it to a fixed width
+
+```python
+from drawzero import *
+from pathlib import Path
+
+this_file_dir = Path(__file__).resolve().parent
+logo_path = this_file_dir / 'assets' / 'school_logo.png'
+
+# Draw the logo 300 units wide and keep it centered on the canvas
+logo_width = 300
+logo_x = 500 - logo_width // 2
+logo_y = 300
+image(logo_path, (logo_x, logo_y), width=logo_width)
+```
+
+This snippet works even if you move the script to another computer, because the path is built relative to the file location.
+
+### Example 3 – ghost trail using alpha
+
+```python
+from drawzero import *
+
+fill('black')
+for step in range(5):
+    image('spaceship.png', (150 + step * 80, 400), width=200, alpha=255 - step * 40)
+```
+
+The loop draws five copies of the same image. Each copy is more transparent than the previous one, creating a motion trail.
+
+### Example 4 – responsive width based on the window size
+
+```python
+from drawzero import *
+
+fill((10, 10, 40))
+window_width = 800  # imagine we measured the real window
+picture_width = int(window_width * 0.6)
+image('city.png', (100, 200), width=picture_width)
+```
+
+Because the width is calculated in code, you can adapt it to different screen sizes.
+
+## Checklist before calling `image()`
+
+1. Place your picture file in the project folder (for example `docs/` or `assets/`).
+2. Confirm the Python script can reach the file path (print it if needed).
+3. Decide the placement coordinates. Use `grid()` from DrawZero if you need help visualizing positions.
+4. Choose a width or leave it as `None`.
+5. Decide whether you need extra transparency.
+6. Only then call `image()`.
+
+## Troubleshooting guide
+
+| Problem | Likely cause | How to fix |
+|---------|--------------|------------|
+| `BadDrawParmsError: bad coords` | The `pos` argument is not a two-number tuple or list. | Make sure you pass `(x, y)` with numbers. |
+| `No file '...' found in working directory` | The image path is wrong. | Print `Path(image).resolve()` and verify the file exists there. |
+| Image looks stretched | You set both `width` and `height`. Only `width` should be supplied. | Remove any manual height scaling. DrawZero calculates it for you. |
+| Image is very blurry | You scaled a tiny picture to a huge size. | Start with a higher-resolution file or reduce the target width. |
+| Transparent PNG looks too solid | You used `alpha=255`. | Lower the alpha value to let the background show through. |
+
+With these tips you can confidently display images and combine them with the drawing primitives.

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -1,8 +1,8 @@
 # Drawing primitives
 
-This page shows how to use the most common drawing helpers in DrawZero.  
-The goal is to help you make nice sketches even if you are new to programming.  
-We will focus on color names, points, and shapes. We will talk about transparency (`alpha`) and line thickness (`line_width`) on another page.
+This page shows how to use the most common drawing helpers in DrawZero.
+The goal is to help you make nice sketches even if you are new to programming.
+We will focus on color names, points, and shapes. Read [Transparency (`alpha`) and line thickness (`line_width`)](transparency_and_line_width.md) when you want to control see-through effects or stroke sizes.
 
 Each example starts with the same import:
 
@@ -316,7 +316,7 @@ Calling `fill('white')` removes old drawings by painting the entire canvas white
 ## Ellipses, arcs, and rotated rectangles
 
 These helpers let you create stretched circles and tilted rectangles. They follow the same color rules you saw before: you can
-use color names, RGB triples, or values from `C`. We will talk about `alpha` and `line_width` in their own section later.
+use color names, RGB triples, or values from `C`. For transparency and stroke size tips, read [Transparency (`alpha`) and line thickness (`line_width`)](transparency_and_line_width.md).
 
 ### `ellipse(color='red', pos=(100, 100), width=500, height=200, *args, alpha=255, line_width: int = None)`
 

--- a/docs/transparency_and_line_width.md
+++ b/docs/transparency_and_line_width.md
@@ -1,0 +1,166 @@
+# Transparency (`alpha`) and line thickness (`line_width`)
+
+Many DrawZero helpers accept two optional parameters: `alpha` for transparency and `line_width` for stroke thickness. This page explains what they do, when to use them, and how to avoid common mistakes. The tone stays simple so that learners with basic English can still follow the ideas.
+
+## Why these parameters matter
+
+* `alpha` controls how much the background shows through your drawing. Lower values make the object look lighter or ghost-like. Higher values make it solid.
+* `line_width` controls how thick the outline of a shape or line appears. Thin lines are great for details. Thick lines help emphasize borders or UI panels.
+
+Together, these parameters let you build depth, focus, and style in your sketches.
+
+## Quick reference
+
+| Parameter | Works with | Default value | Allowed values |
+|-----------|------------|----------------|----------------|
+| `alpha` | `line`, `circle`, `filled_circle`, `rect`, `filled_rect`, `ellipse`, `filled_ellipse`, `arc`, `polygon`, `filled_polygon`, `rect_rotated`, `filled_rect_rotated`, `fill`, `image` | `255` | Any integer from `0` to `255` |
+| `line_width` | Outline helpers such as `line`, `circle`, `rect`, `ellipse`, `arc`, `polygon`, `rect_rotated` | `4` (virtual units, roughly 4 pixels on the default 1000×1000 canvas) | Non-negative integers. Use `0` to fill shapes through the outline helper. |
+
+> 💡 Filled helpers (`filled_circle`, `filled_rect`, and so on) already set `line_width=0` internally, so you usually do not need to pass it yourself.
+
+## Understanding `alpha`
+
+`alpha` measures opacity on a scale from `0` (fully transparent) to `255` (fully opaque). DrawZero rounds the value to an integer, so pass whole numbers.
+
+| Value | Visual result |
+|-------|----------------|
+| `0` | The object becomes invisible. Good for hiding elements without deleting code. |
+| `64` | Very light ghost of the original color. Useful for shadows and planning guides. |
+| `128` | Half-transparent. Background is clearly visible through the object. |
+| `192` | Mostly solid with a soft edge. Great for highlights. |
+| `255` | Fully solid. Default setting. |
+
+### Layered example – glowing button
+
+```python
+from drawzero import *
+
+fill((20, 20, 35))
+base = (500, 500)
+filled_circle('#4caf50', base, 120, alpha=220)
+filled_circle('#81c784', base, 90, alpha=160)
+filled_circle('white', base, 60, alpha=90)
+text('white', 'PLAY', base, 48, '.^')
+```
+
+Each circle uses a different alpha value. The background shines through the outer rings, creating a glow effect.
+
+### Example – glass window using shapes
+
+```python
+from drawzero import *
+
+fill('#202840')
+rect('white', (150, 200), 700, 500, line_width=12)
+filled_rect('#90caf9', (150, 200), 700, 500, alpha=120)
+line('white', (150, 450), (850, 450), alpha=160, line_width=6)
+line('white', (500, 200), (500, 700), alpha=160, line_width=6)
+```
+
+The rectangle outline stays solid, while the inner filled rectangle uses a medium alpha to look like glass.
+
+### Example – fading image copies
+
+```python
+from drawzero import *
+
+fill('black')
+for layer, opacity in enumerate(range(200, 40, -40)):
+    image('runner.png', (200 + layer * 60, 420), width=220, alpha=opacity)
+```
+
+This snippet combines `image()` with different alpha values to show a runner leaving a trail. For more details about the `image()` helper, read [Working with images](images.md).
+
+### Tips for using `alpha`
+
+* Keep alpha values between `30` and `80` for soft shadows and between `120` and `200` for glow or UI overlays.
+* When stacking several transparent layers, start drawing from the darkest background to the lightest foreground.
+* `alpha` multiplies any transparency already stored in a PNG image. A semi-transparent pixel with per-pixel alpha `128` becomes even lighter if you call `image(..., alpha=128)`.
+* Passing `None` or leaving the argument out uses the default value `255`.
+* Values outside the range raise a `BadDrawParmsError`. Double-check that your code produces integers.
+
+## Understanding `line_width`
+
+`line_width` describes how thick the outline of a primitive should be. The value is measured in virtual canvas units. On the default 1000×1000 canvas, one unit is roughly one pixel.
+
+| `line_width` | Visual style |
+|--------------|--------------|
+| `1`–`2` | Very thin lines for delicate details or sketch guides. |
+| `3`–`6` | Standard outlines. The default `4` lives here. |
+| `8`–`12` | Heavy borders for panels, speech bubbles, or map outlines. |
+| `20` and above | Bold graphic style. Useful for cartoon shadows or timelines. |
+| `0` | Special case. The shape becomes filled because the outline has no width. |
+
+### Example – using different line widths on circles
+
+```python
+from drawzero import *
+
+fill('black')
+for step, width in enumerate([2, 4, 8, 16]):
+    circle('cyan', (200 + step * 150, 500), 60, line_width=width)
+    text('white', f'line_width={width}', (200 + step * 150, 620), 24, '.^')
+```
+
+The four circles let you compare how the outline grows as `line_width` increases.
+
+### Example – drawing a filled shape through the outline helper
+
+```python
+from drawzero import *
+
+fill('#263238')
+rect('orange', (250, 250), 500, 300, line_width=0, alpha=220)
+```
+
+Setting `line_width=0` tells the renderer to fill the rectangle. This is how the convenience helper `filled_rect()` works internally.
+
+### Example – precise outlines with polygons
+
+```python
+from drawzero import *
+
+fill('#0d1b2a')
+points = [(200, 800), (500, 200), (800, 800)]
+polygon('#e0e1dd', *points, line_width=6)
+polygon('#778da9', *points, line_width=2, alpha=160)
+```
+
+The first polygon creates a thick border, and the second one on top adds a thin highlight with partial transparency.
+
+### Tips for using `line_width`
+
+* Use the same `line_width` across related elements (for example, all buttons) to keep a consistent style.
+* When drawing animations, cache the chosen value in a variable so it stays constant frame to frame.
+* Large `line_width` values need extra space around the shape. Make sure your coordinates leave padding so the stroke is not cut off by the canvas edge.
+* Negative values are not allowed. If you calculate the width, wrap it in `max(0, value)` to avoid mistakes.
+
+## Mixing `alpha` and `line_width`
+
+These parameters can work together for polished designs.
+
+```python
+from drawzero import *
+
+fill('#1a1a1a')
+outer = (150, 150)
+inner = (250, 250)
+rect('#ff9800', outer, 700, 700, line_width=14, alpha=220)
+rect('#ffc107', inner, 500, 500, line_width=6, alpha=140)
+filled_rect('#ffffff', (320, 420), 360, 200, alpha=30)
+text('white', 'Mission Briefing', (500, 360), 42, '.^')
+```
+
+The outer rectangle has a thick, almost solid stroke. The inner rectangle uses a thinner, more transparent line to add depth. The semi-transparent filled rectangle creates a readable panel.
+
+## Troubleshooting checklist
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Shape looks the same after changing `alpha`. | The helper you used does not accept `alpha` (for example, `text()`). | Check the documentation of that helper. If it lacks `alpha`, draw the text on top of a semi-transparent shape instead. |
+| Stroke looks blurry. | The line width is very large for a small shape. | Reduce `line_width` or increase the shape size. |
+| `BadDrawParmsError: bad alpha`. | The value was outside `0`–`255` or not a number. | Clamp the number or convert it with `int()`. |
+| `BadDrawParmsError: bad width`. | `line_width` was negative or not numeric. | Ensure you pass a non-negative integer. |
+| Transparent layers disappear in random order. | You draw the brightest elements first. Later opaque shapes cover them. | Draw the darkest background first, then lighter transparent layers, then solid highlights. |
+
+With these guidelines you can choose `alpha` and `line_width` values confidently and make your drawings look professional.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,8 @@ nav:
     - Drawing primitives: primitives.md
     - Pt: pt.md
     - Gradient: gradient.md
+    - Working with images: images.md
+    - Transparency and line width: transparency_and_line_width.md
 
 theme:
   name: material


### PR DESCRIPTION
## Summary
- add a "Working with images" reference page that explains the `image()` helper parameters with step-by-step examples
- document how to use the shared `alpha` and `line_width` options in a dedicated guide and link to it from the primitives page
- add the new guides to the MkDocs navigation so they are easy to find

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f735af36b483269c68dbaea3dafa4d