### PR TITLE
Rewrite Pt and Gradient documentation for MkDocs

### DIFF
--- a/docs/examples_overview.md
+++ b/docs/examples_overview.md
@@ -9,15 +9,15 @@ The `src/drawzero/examples` package contains runnable scripts that double as smo
 | `02_loops_and_rgb_colors.py` | Loop-driven art | Uses a `for` loop and random RGB tuples to paint vertical bars with varying heights. |
 | `03_simple_objects.py` | Primitive catalog | Demonstrates every drawing primitive (lines, circles, rotated rectangles, polygons, text alignment). |
 | `04_loops_sin_plot.py` | Math plotting | Plots a sine wave by stitching short line segments along the X axis. |
-| `05_points.py` | `Pt` as vector/turtle | Shows how the `Pt` class supports arithmetic, motion, and turtle-style rotation in loops. |
-| `06_turtle_style.py` | Polygon drawing with `Pt` | Rotates a `Pt` instance to build regular polygons for sides 3–10 using turtle operations. |
+| `05_points.py` | [`Pt` helper](pt.md) as vector/turtle | Shows how the `Pt` class supports arithmetic, motion, and turtle-style rotation in loops. |
+| `06_turtle_style.py` | Polygon drawing with [`Pt`](pt.md) | Rotates a `Pt` instance to build regular polygons for sides 3–10 using turtle operations. |
 | `07_animation_circles.py` | Minimal animation loop | Varies circle position, radius, and color over time while calling `tick()` each frame. |
 | `08_animation_traffic_light.py` | State-based animation | Reuses a helper to draw a traffic light and uses `sleep()` to cycle colors. |
 | `09_animation_rectangles.py` | Complex animation | Combines `Pt` math with rotation/orbit logic, transparency, and conditional effects. |
 | `10_animation_planets.py` | Orbital motion | Calculates circular motion for a planet/moon pair and redraws every frame. |
 | `11_transparency_and_line_width.py` | Alpha blending and stroke widths | Samples different alpha values and line widths across circles, rectangles, polygons, and ellipses. |
 | `12_images.py` | Image rendering | Loads `cat.png` from the examples folder, demonstrates scaling and alpha when blitting images. |
-| `13_gradients.py` | Gradient helper | Builds several `Gradient` scales and visualizes them through stacked rectangles. |
+| `13_gradients.py` | [Gradient helper](gradient.md) | Builds several `Gradient` scales and visualizes them through stacked rectangles. |
 | `14_animation_close_vertex.py` | Proximity graph animation | Moves random `Pt` nodes with wrap-around motion, draws lines between nearby pairs, and uses FPS overlay. |
 | `15_animation_firework.py` | Particle system | Implements `Particle` and `Firework` classes with physics updates, gradient-based glow, and clean-up logic. |
 | `16_keyboard_and_mouse.py` | Input handling | Reads key state arrays and event queues to move a square, track typed characters, and follow the mouse. |

--- a/docs/gradient.md
+++ b/docs/gradient.md
@@ -1,4 +1,166 @@
-::: src.drawzero.utils.gradient
-    options:
-      show_bases: false
-      show_source: true
+# Gradient helper reference
+
+`Gradient` is a class that turns a number into a color.  
+It lives in [`drawzero.utils.gradient`](../src/drawzero/utils/gradient.py) and is available after `from drawzero import *`.
+Use it when you need smooth color transitions for temperature maps, progress bars, particle systems, or animated trails.
+
+This guide replaces the bare auto-doc block and explains the helper step by step.  
+It also shows how to combine gradients with shapes from [Drawing primitives](primitives.md), transparency tips from
+[Transparency and line width](transparency_and_line_width.md), and animated loops from [Animations](animation.md).
+
+## Quick start
+
+```python
+from drawzero import *
+
+heat = Gradient([C.blue, C.cyan, C.yellow, C.red])
+print(heat(0.0))   # (0, 0, 255) - first color
+print(heat(0.5))   # (0, 255, 255) - middle color
+print(heat(1.0))   # (255, 0, 0) - last color
+```
+
+* The first argument is a list of colors. You can mix constants from `drawzero.utils.colors.C`, named strings (`'gold'`), or RGB tuples like `(34, 139, 34)`.
+* By default the valid input range (the **domain**) goes from `0` to `1`.
+* Passing a value smaller than the start clamps to the first color; bigger values clamp to the last color.
+
+## Why gradients are useful
+
+* **Continuous shading** – draw rectangles that fade from cold to hot numbers.
+* **Animated effects** – change particle colors as they age.
+* **Status bars** – map progress (0–100) to a palette.
+
+Open the example [`13_gradients.py`](../src/drawzero/examples/13_gradients.py) after reading this page. The file is also listed in the [Examples overview](examples_overview.md).
+
+## Constructing a gradient
+
+```
+Gradient(color_list, start=0.0, end=1.0, *extra_domain_points)
+```
+
+* `color_list` must have at least two entries.
+* If you pass only `start` and `end`, the helper spreads the colors evenly across that range.
+* When you supply extra numbers, the helper sorts them automatically. The final domain always has the same length as `color_list`.
+
+### Evenly spaced domain
+
+```python
+heat = Gradient([C.blue, C.white, C.red], 0, 100)
+print(heat(0))     # blue
+print(heat(50))    # white
+print(heat(100))   # red
+```
+
+The colors sit at 0, 50, and 100 because the list has three entries.
+
+### Custom positions for each color
+
+```python
+mist = Gradient([C.black, 'purple', C.white], 0, 30, 100)
+print(mist(10))   # dark purple
+print(mist(60))   # pale purple near white
+```
+
+Here the palette stays dark longer because the middle color is close to the start of the domain.
+
+### Using raw RGB tuples
+
+```python
+sunrise = Gradient([(25, 25, 112), (255, 140, 0), (255, 215, 0)], -1, 1)
+```
+
+Any number outside `[-1, 1]` will clamp to the first or last tuple.
+
+### Validation rules
+
+If the domain points do not match the number of colors, `Gradient` raises `BadDrawParmsError`.  
+The message suggests a fixed call such as `Gradient([C.red, C.green], 0, 100)`.
+
+## Sampling colors inside drawings
+
+`Gradient` objects are callable. You can pass the result straight into the drawing helpers.
+
+```python
+from drawzero import *
+
+glow = Gradient([C.black, C.blue, C.cyan, C.white])
+
+for index in range(10):
+    color = glow(index / 9)   # 0.0 .. 1.0
+    filled_circle(color, (500, 500), 40 + index * 15)
+```
+
+Combine this with alpha values from [Transparency and line width](transparency_and_line_width.md) to create soft halos.
+
+### Heat map rectangle grid
+
+```python
+from drawzero import *
+
+heat = Gradient([C.darkblue, C.lawngreen, C.yellow, C.orangered], 0, 30)
+cell_size = 80
+
+for row in range(5):
+    for col in range(5):
+        value = row * 5 + col  # pretend sensor reading
+        color = heat(value)
+        filled_rect(color, (100 + col * cell_size, 100 + row * cell_size), cell_size, cell_size)
+        text('white', f"{value}", (110 + col * cell_size, 110 + row * cell_size))
+```
+
+The helper clamps any number above `30` to the last color (`C.orangered`).
+
+## Mapping animation progress to colors
+
+Gradients pair very well with the `tick()` loop from [Animations](animation.md).
+
+```python
+from drawzero import *
+
+trail = Gradient([C.white, C.skyblue, C.blue, C.navy])
+ball = Pt(200, 500, heading=0)
+
+while tick():
+    clear()
+    for tail in range(20):
+        color = trail(tail / 19)
+        filled_circle(color, (ball.x - tail * 12, ball.y), 20 - tail)
+    ball.forward(5)
+    if ball.x > 1000:
+        ball.goto(0, ball.y)
+```
+
+The gradient gives darker colors for older trail segments while the point keeps moving.
+
+## Understanding interpolation
+
+Between two domain values the helper blends color channels linearly:
+
+```
+channel = left_channel * (right_x - current_x) / diff + right_channel * (current_x - left_x) / diff
+```
+
+Each channel (`R`, `G`, `B`) is rounded to the nearest integer.  
+You normally do not need to worry about this math, but it helps explain why gradients produce smooth steps even when the domain spacing is uneven.
+
+## Tips and troubleshooting
+
+* **Domain must be sorted.** The helper sorts your numbers automatically, but passing mixed strings and numbers triggers an error message.
+* **Short palettes need matching domain length.** Two colors work with two domain points. Three colors need three points, and so on.
+* **Re-use gradients.** Store the object once (e.g. `heat = Gradient(...)`) and call it many times per frame instead of creating new gradients inside loops.
+* **Combine with alpha.** Use the `alpha` keyword from [Transparency and line width](transparency_and_line_width.md) to fade shapes even more.
+* **Test in the shell.** Gradients have a readable `repr`, so printing them helps during debugging.
+
+```python
+heat = Gradient([C.blue, C.white, C.red], 0, 100)
+print(heat)
+# Gradient([(0, 0, 255), (255, 255, 255), (255, 0, 0)], 0, 50.0, 100)
+```
+
+## Where to read more
+
+* [Drawing primitives](primitives.md) – shows every function that accepts colors.
+* [Pt helper](pt.md) – use moving points together with gradients for animated trails.
+* [Examples overview](examples_overview.md) – find `13_gradients.py` plus other scripts that mix gradients with motion.
+* [Architecture notes](architecture.md) – quick summary of how utility helpers (including `Gradient`) fit into the project.
+
+Try creating your own palette, then feed its colors into shapes, particle effects, or HUD elements. Small experiments make the gradient rules stick quickly.

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -4,6 +4,9 @@ This page shows how to use the most common drawing helpers in DrawZero.
 The goal is to help you make nice sketches even if you are new to programming.
 We will focus on color names, points, and shapes. Read [Transparency (`alpha`) and line thickness (`line_width`)](transparency_and_line_width.md) when you want to control see-through effects or stroke sizes.
 
+If you want to move a point around with turtle-style steps, open the [Pt helper reference](pt.md).
+For smooth color transitions or animated trails, check the [Gradient helper reference](gradient.md).
+
 Once you feel comfortable drawing static shapes, jump to the [Animations guide](animation.md).
 It explains how to put your drawings inside the frame loop, control the speed with `tick()`, and even make motion trails.
 

--- a/docs/pt.md
+++ b/docs/pt.md
@@ -1,4 +1,274 @@
-::: src.drawzero.utils.pt
-    options:
-      show_bases: false
-      show_source: true
+# Pt helper reference
+
+The `Pt` class is a small helper that acts both like a 2D point and like a very light turtle.  
+It lives in [`drawzero.utils.pt`](../src/drawzero/utils/pt.py) and is imported for you when you write `from drawzero import *`.
+Use `Pt` whenever you want to store a position, move it around, and pass it into the drawing helpers from
+[Drawing primitives](primitives.md) or [Animations](animation.md).
+
+This page explains the full `Pt` API in simple language, with many short examples that you can copy into
+an interactive shell or one of the example scripts.  It replaces the auto-generated snippet that used to be here.
+
+## Quick import and first steps
+
+```python
+from drawzero import *
+
+point = Pt()          # (0, 0) facing east (heading = 0°)
+other = Pt(200, 150)  # x=200, y=150
+```
+
+`Pt` stores three values:
+
+* `x` – horizontal coordinate (0 is the left edge of the canvas).
+* `y` – vertical coordinate (0 is the top edge).
+* `heading` – direction in degrees. `0` means “pointing right”, `90` means “pointing up”.
+
+All drawing helpers accept a `Pt` object anywhere they expect a coordinate pair. For example:
+
+```python
+from drawzero import *
+
+center = Pt(500, 400)
+point = Pt(200, 200)
+
+filled_circle('gold', center, 80)
+line('black', point, center)  # `line` reads the `(x, y)` from each Pt
+```
+
+## Creating and reading points
+
+### Constructors
+
+```python
+Pt()
+Pt(x_value, y_value)
+Pt(x_value, y_value, heading=degrees)
+```
+
+* All numbers can be integers or floats.
+* If you leave `heading` out, DrawZero assumes `0` degrees.
+
+### Getting the stored values
+
+```python
+point = Pt(120, 345, heading=30)
+
+point.x        # 120
+point.y        # 345
+point.heading  # 30
+
+point.pos()       # (120.0, 345.0)
+point.position()  # same as pos()
+point.xcor()      # 120.0
+point.ycor()      # 345.0
+```
+
+The `xcor`/`ycor` helpers round the values to 10 decimal places so the output stays tidy in the console.
+
+## Vector-style arithmetic
+
+`Pt` behaves like a mutable 2D vector. You can add, subtract, and scale points without writing your own loops.
+Each operation creates a new `Pt` unless it ends with `=` (like `+=`).
+
+```python
+start = Pt(50, 20)
+offset = Pt(10, -5)
+
+result = start + offset   # Pt(60, 15, heading=0.0)
+start += offset           # start is now Pt(60, 15, heading=0.0)
+mirror = -offset          # Pt(-10, 5, heading=0.0)
+```
+
+Scaling works with plain numbers:
+
+```python
+point = Pt(5, 8)
+print(point * 3)     # Pt(15, 24, heading=0.0)
+print(2 * point)     # Pt(10, 16, heading=0.0)
+print(point / 2)     # Pt(2.5, 4.0, heading=0.0)
+```
+
+When you need only the length of the vector, call `abs(point)`.
+
+```python
+hyp = Pt(3, 4)
+print(abs(hyp))  # 5.0
+```
+
+### Copying and unpacking
+
+Use `.copy()` to duplicate the point while keeping the original intact.
+
+```python
+head = Pt(100, 100)
+shadow = head.copy()
+head.forward(50)
+# `shadow` still remembers the old coordinates
+```
+
+`Pt` also supports unpacking and indexing:
+
+```python
+p = Pt(7, 9)
+
+x, y = p        # iterates over x then y
+p[0]            # 7
+p[1]            # 9
+p[:2]           # [7, 9]
+len(p)          # always 2
+```
+
+## Turtle-style movement
+
+`Pt` keeps a heading angle and can move in that direction. This is perfect for drawing polygons or animation paths.
+
+```python
+walker = Pt()
+walker.forward(100)   # moves along heading (initially east)
+walker.right(90)
+walker.forward(50)
+print(walker.pos())   # (100.0, 50.0)
+```
+
+Key methods and their aliases:
+
+| Action | Preferred name | Aliases |
+| --- | --- | --- |
+| Move forward | `forward(distance)` | `fd(distance)` |
+| Move backward | `backward(distance)` | `back(distance)`, `bk(distance)` |
+| Turn right | `right(angle)` | `rt(angle)` |
+| Turn left | `left(angle)` | `lt(angle)` |
+| Set heading directly | `setheading(angle)` | `seth(angle)` |
+| Reset to origin | `reset()` or `home()` | — |
+
+Headings always wrap to the range `[0, 360)`.
+
+### Example – regular polygon helper
+
+```python
+from drawzero import *
+from math import sin, pi
+
+def regular_polygon(center, sides, radius):
+    corner = Pt(center.x, center.y - radius)
+    corner.setheading(0)
+    angle = 360 / sides
+    vertices = []
+    for _ in range(sides):
+        vertices.append(corner.pos())
+        corner.right(angle)
+        corner.forward(2 * radius * sin(pi / sides))
+    polygon('white', vertices)
+
+regular_polygon(Pt(300, 300), sides=6, radius=120)
+```
+
+`polygon` comes from [Drawing primitives](primitives.md). `Pt` supplies the vertex coordinates.
+
+## Absolute moves and rotations
+
+Sometimes you need to jump to a location or rotate around another point.
+
+* `goto(x, y)` / `setpos(...)` / `setposition(...)` – move to exact coordinates without changing heading.
+* `rotate_around(angle, pivot)` – spin around another `Pt`, tuple, or list.
+* `move_towards(distance, target)` – move a fixed distance in the direction of another point.
+
+```python
+p = Pt(100, 100)
+p.goto(400, 200)           # -> Pt(400, 200, heading=0.0)
+p.rotate_around(90, (200, 200))  # pivot around absolute point
+p.move_towards(50, Pt(200, 500))
+```
+
+`rotate_around` rotates counter-clockwise when the angle is positive. If you need the shortest path towards a target, `move_towards`
+combines the direction and step size for you.
+
+## Distance and angle helpers
+
+```python
+p = Pt(0, 0)
+q = Pt(30, 40)
+
+p.distance(q)      # 50.0
+p.towards(q)       # 53.1301023542 degrees
+p.is_left_of(10)   # True because 0 < 10
+p.is_right_of(-5)  # True because 0 > -5
+```
+
+Comparison helpers use the canvas axes:
+
+* `is_above(y_value)` returns `True` if the point is higher on the screen (smaller `y`).
+* `is_below(y_value)` returns `True` if the point is lower on the screen (larger `y`).
+* `is_left_of(x_value)` returns `True` if `x` is smaller.
+* `is_right_of(x_value)` returns `True` if `x` is larger.
+
+Use them to keep sprites within bounds:
+
+```python
+ball = Pt(500, -10, heading=90)
+if ball.is_above(0):
+    ball.flip_vertically()  # bounce from the top edge
+```
+
+`flip_vertically()` and `flip_horizontally()` mirror the heading without changing the position. This is handy for collision logic in small games.
+
+## Working with drawing helpers
+
+Most drawing helpers accept `Pt` objects directly. You can mix plain tuples and points in the same call.
+
+```python
+from drawzero import *
+
+start = Pt(150, 150)
+end = Pt(600, 300)
+
+line('cyan', start, end)
+rect('orange', start, 200, 120)
+filled_circle('white', end, 40)
+```
+
+For shapes that expect a list of vertices (like `polygon` or `filled_polygon`), call `.pos()` on each `Pt`.
+
+```python
+triangle = [Pt(400, 200), Pt(300, 450), Pt(500, 450)]
+polygon('white', [p.pos() for p in triangle])
+```
+
+To connect the dots with animation, combine this page with [Animations](animation.md) and the
+`tick()` call shown there.
+
+## Using Pt inside loops and animations
+
+`Pt` shines when you update positions every frame. The example below creates a simple orbit.
+
+```python
+from drawzero import *
+
+center = Pt(500, 500)
+planet = Pt(650, 500)
+planet.setheading(90)
+
+while tick():
+    clear()
+    filled_circle('navy', center, 40)
+    filled_circle('orange', planet, 20)
+    planet.rotate_around(3, center)
+```
+
+Read [Examples overview](examples_overview.md) and open `05_points.py` or `09_animation_rectangles.py` to see longer scripts that use these methods together.
+
+## Troubleshooting tips
+
+* **Movement looks wrong?** Remember that the screen origin `(0, 0)` is the top-left corner. Moving “up” means decreasing `y`.
+* **Heading jumps unexpectedly?** Check if you used `backward()` or `forward()` with negative numbers. Both change the point but keep the heading.
+* **`distance` returns a float with many decimals.** That is normal. Use `round(value, 2)` when printing if you want fewer digits.
+* **Need to reset everything?** Call `reset()` or `home()` to set `(x, y)` to `(0, 0)` and `heading` to `0`.
+
+## Where to go next
+
+* [Drawing primitives](primitives.md) – shapes and text helpers that happily accept `Pt` objects.
+* [Animations](animation.md) – how to redraw every frame and schedule updates with `tick()`.
+* [Gradient helper](gradient.md) – smooth color transitions that go well with moving points.
+* [Examples overview](examples_overview.md) – table of scripts, including the ones that focus on `Pt`.
+
+Experiment with the snippets above, then mix `Pt` with the other utilities to build your own scenes.


### PR DESCRIPTION
## Summary
- replace the old mkdocstrings stubs for `Pt` and `Gradient` with detailed, student-friendly guides that include examples and cross-links
- add forward links from the drawing primitives page to the new helper references
- link the example overview table entries to the Pt and Gradient documentation for quick navigation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68fb3f99b75c832684deb2efb95c15f0